### PR TITLE
Minor fix to includes and to address ISO C++ warnings

### DIFF
--- a/iffdigest.h
+++ b/iffdigest.h
@@ -28,9 +28,9 @@ protected:
   iff_ckid_t ckid;
   char tnull; 		// terminating null for id
   enum { IFF_CHUNK_DATA, IFF_CHUNK_LIST } ctype;
+  IFFChunkList subchunks;
   const char* data;
   unsigned int length;
-  IFFChunkList subchunks;
   
 public:
   IFFChunk(unsigned int id, const char* d, unsigned int l) 

--- a/ifflist.cc
+++ b/ifflist.cc
@@ -3,7 +3,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <fcntl.h>
-#include <iostream.h>
+#include <iostream>
 #include <stdio.h>
 
 void
@@ -26,10 +26,10 @@ dump_chunk_list(IFFChunkIterator from, IFFChunkIterator to, int level=0)
   }
 }
 
-main(int argc, char* argv[])
+int main(int argc, char* argv[])
 {
   if(argc<2) {
-    cerr<<"usage: "<<argv[0]<<" filename\n";
+    std::cerr<<"usage: "<<argv[0]<<" filename\n";
     return 2;
   }
   int fd = open(argv[1], O_RDONLY);
@@ -41,7 +41,7 @@ main(int argc, char* argv[])
     dump_chunk_list(iff.ck_begin(), iff.ck_end(), 0);
     return 0;
   } else {
-    cerr<<argv[0]<<": "<<argv[1]<<" is not a legal EA-IFF-85 or RIFF file.\n";
+    std::cerr<<argv[0]<<": "<<argv[1]<<" is not a legal EA-IFF-85 or RIFF file.\n";
     return 1;
   }
 }

--- a/wavtest.cc
+++ b/wavtest.cc
@@ -6,7 +6,7 @@
 #include <unistd.h>
 #include <iostream>
 
-main(int argc, char* argv[])
+int main(int argc, char* argv[])
 {
   if(argc<2) {
     std::cerr<<"usage: "<<argv[0]<<" filename\n";


### PR DESCRIPTION
Just needed to make some minor fixes to get it to compile and show no warnings. Using your library to learn how to parse PCM (WAV) files; this is the most robust library I have found!